### PR TITLE
Use correct casing to import Meaning.default

### DIFF
--- a/lib/Meaning.Credentials.coffee
+++ b/lib/Meaning.Credentials.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-DEFAULT       = require './Meaning.DEFAULT'
+DEFAULT       = require './Meaning.default'
 existsDefault = require 'existential-default'
 
 ###*

--- a/lib/Meaning.coffee
+++ b/lib/Meaning.coffee
@@ -2,7 +2,7 @@
 
 got         = require 'got'
 pkg         = require './../package.json'
-DEFAULT     = require './Meaning.DEFAULT'
+DEFAULT     = require './Meaning.default'
 Endpoints   = require './Meaning.Endpoints'
 Credentials = require './Meaning.Credentials'
 


### PR DESCRIPTION
Not all filesystems are case-insensitive
